### PR TITLE
Add JWT (EdDSA/Ed25519) authentication alongside API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ English | [简体中文](./README.zh-CN.md)
 
 - 🌤️ Real-time weather queries
 - 📅 Multi-day weather forecasts (3/7/10/15/30 days)
-- 🔑 Simple API key configuration
+- 🔐 JWT (EdDSA/Ed25519) **and** legacy API Key authentication
 - 🔌 Custom API base URL support
 - 🛠️ Complete tool integration
 
@@ -27,8 +27,7 @@ npx -y @smithery/cli install @overstarry/qweather-mcp --client claude
 
 ### Manual Configuration
 
-1. First, get your API Key from the [QWeather Console](https://console.qweather.com/).
-
+1. First, get your credentials from the [QWeather Console](https://console.qweather.com/).
 2. Start the server:
 
 ```bash
@@ -36,16 +35,53 @@ npx -y @smithery/cli install @overstarry/qweather-mcp --client claude
 npx -y qweather-mcp
 ```
 
-3. Configure environment variables:
+3. Configure environment variables (pick **one** of the two auth modes below).
+
+### 🔐 JWT Authentication (recommended)
+
+QWeather has announced that **API Key authentication will be deprecated in 2027** and recommends migrating to JWT (EdDSA + Ed25519). Generate an Ed25519 key pair, upload the public key to the QWeather console, and configure:
+
+```bash
+QWEATHER_API_BASE=https://<your-host>.qweatherapi.com
+QWEATHER_PROJECT_ID=<project-id>
+QWEATHER_KEY_ID=<credential-id>
+# Either pass the PEM path…
+QWEATHER_PRIVATE_KEY_PATH=/path/to/ed25519-private.pem
+# …or the PEM content directly (newlines preserved)
+# QWEATHER_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+```
+
+If both `QWEATHER_PRIVATE_KEY_PATH` and `QWEATHER_PRIVATE_KEY` are provided, the path takes precedence. For `QWEATHER_PRIVATE_KEY`, the literal two-character sequence `\n` is auto-converted to real newlines, so the single-line form above works in shells, `.env` files, and JSON configs.
+
+JSON config example:
+
+```json
+{
+  "mcpServers": {
+    "qweather": {
+      "command": "npx",
+      "args": ["-y", "qweather-mcp"],
+      "env": {
+        "QWEATHER_API_BASE": "https://<your-host>.qweatherapi.com",
+        "QWEATHER_PROJECT_ID": "<project-id>",
+        "QWEATHER_KEY_ID": "<credential-id>",
+        "QWEATHER_PRIVATE_KEY_PATH": "/path/to/ed25519-private.pem"
+      }
+    }
+  }
+}
+```
+
+JWT details: tokens are signed with `alg=EdDSA`, `iat` is back-dated 30s to tolerate clock skew, `exp = iat + 900s` (15 min, well under QWeather's 24h cap), and tokens are cached and reused until ~30s before expiry. See the [official authentication docs](https://dev.qweather.com/docs/configuration/authentication/#json-web-token).
+
+### 🔑 API Key Authentication (legacy)
 
 ```bash
 QWEATHER_API_BASE=https://api.qweather.com
 QWEATHER_API_KEY=<your-api-key>
 ```
 
-### JSON Configuration
-
-Add to your configuration file:
+JSON config example:
 
 ```json
 {
@@ -61,6 +97,19 @@ Add to your configuration file:
   }
 }
 ```
+
+### Mode detection
+
+| Env vars present | Mode |
+|---|---|
+| Full JWT vars (`QWEATHER_PROJECT_ID` + `QWEATHER_KEY_ID` + `QWEATHER_PRIVATE_KEY[_PATH]`) | **JWT** (wins even if `QWEATHER_API_KEY` is also set) |
+| Full JWT vars + `QWEATHER_API_KEY` | **JWT** (API Key is ignored) |
+| Partial JWT vars + `QWEATHER_API_KEY` | API Key, with a startup warning to stderr |
+| Partial JWT vars only | startup error |
+| `QWEATHER_API_KEY` only | API Key |
+| neither | startup error |
+
+The active mode is logged to stderr at startup, e.g. `Weather MCP Server running on stdio (auth: JWT/EdDSA)`.
 
 ## 🛠️ Available Tools
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
 
 - 🌤️ 实时天气查询
 - 📅 多天天气预报（3/7/10/15/30天）
-- 🔑 简单的API密钥配置
+- 🔐 同时支持 JWT (EdDSA/Ed25519) 与传统 API Key 认证
 - 🔌 自定义API基础URL支持
 - 🛠️ 完整的工具集成
 
@@ -27,8 +27,7 @@ npx -y @smithery/cli install @overstarry/qweather-mcp --client claude
 
 ### 手动配置
 
-1. 首先，从[和风天气控制台](https://console.qweather.com/)获取您的API密钥。
-
+1. 首先，从[和风天气控制台](https://console.qweather.com/)获取您的凭据。
 2. 启动服务器：
 
 ```bash
@@ -36,16 +35,53 @@ npx -y @smithery/cli install @overstarry/qweather-mcp --client claude
 npx -y qweather-mcp
 ```
 
-3. 配置环境变量：
+3. 配置环境变量（在下面两种认证方式中**任选其一**）。
+
+### 🔐 JWT 认证（推荐）
+
+和风天气已宣布 **API Key 将于 2027 年弃用**，建议迁移到 JWT (EdDSA + Ed25519)。请先生成 Ed25519 密钥对，将公钥上传至和风天气控制台，然后配置：
+
+```bash
+QWEATHER_API_BASE=https://<your-host>.qweatherapi.com
+QWEATHER_PROJECT_ID=<项目ID>
+QWEATHER_KEY_ID=<凭据ID>
+# 方式一：传入 PEM 文件路径
+QWEATHER_PRIVATE_KEY_PATH=/path/to/ed25519-private.pem
+# 方式二：直接传入 PEM 内容（保留换行）
+# QWEATHER_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+```
+
+如果同时设置了 `QWEATHER_PRIVATE_KEY_PATH` 和 `QWEATHER_PRIVATE_KEY`，路径优先生效。`QWEATHER_PRIVATE_KEY` 中的字面 `\n`（两字符序列）会自动转换为真实换行，因此 shell、`.env` 文件和 JSON 配置中的单行写法均可直接使用。
+
+JSON 配置示例：
+
+```json
+{
+  "mcpServers": {
+    "qweather": {
+      "command": "npx",
+      "args": ["-y", "qweather-mcp"],
+      "env": {
+        "QWEATHER_API_BASE": "https://<your-host>.qweatherapi.com",
+        "QWEATHER_PROJECT_ID": "<项目ID>",
+        "QWEATHER_KEY_ID": "<凭据ID>",
+        "QWEATHER_PRIVATE_KEY_PATH": "/path/to/ed25519-private.pem"
+      }
+    }
+  }
+}
+```
+
+JWT 细节：使用 `alg=EdDSA` 签名；`iat` 回拨 30 秒以容忍时钟漂移；`exp = iat + 900s`（15 分钟，远低于官方 24h 上限）；Token 缓存复用，过期前约 30 秒才会重新签发。详见[官方认证文档](https://dev.qweather.com/docs/configuration/authentication/#json-web-token)。
+
+### 🔑 API Key 认证（传统方式）
 
 ```bash
 QWEATHER_API_BASE=https://api.qweather.com
 QWEATHER_API_KEY=<your-api-key>
 ```
 
-### JSON 配置
-
-在您的配置文件中添加：
+JSON 配置示例：
 
 ```json
 {
@@ -61,6 +97,19 @@ QWEATHER_API_KEY=<your-api-key>
   }
 }
 ```
+
+### 模式检测
+
+| 已设置的环境变量 | 启用模式 |
+|---|---|
+| 完整 JWT 变量（`QWEATHER_PROJECT_ID` + `QWEATHER_KEY_ID` + `QWEATHER_PRIVATE_KEY[_PATH]`） | **JWT**（即使同时设置了 `QWEATHER_API_KEY` 也优先走 JWT） |
+| 完整 JWT 变量 + `QWEATHER_API_KEY` | **JWT**（API Key 被忽略） |
+| 部分 JWT 变量 + `QWEATHER_API_KEY` | API Key，并向 stderr 输出警告 |
+| 仅部分 JWT 变量 | 启动报错 |
+| 仅 `QWEATHER_API_KEY` | API Key |
+| 都未设置 | 启动报错 |
+
+启动时 stderr 会打印当前生效的认证模式，例如：`Weather MCP Server running on stdio (auth: JWT/EdDSA)`。
 
 ## 🛠️ 可用工具
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,20 @@
 {
   "name": "qweather-mcp",
-  "version": "1.0.0",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qweather-mcp",
-      "version": "1.0.0",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.8.0",
+        "jose": "^5.9.6",
         "zod": "^3.24.2"
+      },
+      "bin": {
+        "qweather-mcp": "cli.js"
       },
       "devDependencies": {
         "@types/node": "^22.14.0",
@@ -534,6 +538,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.8.0",
+    "jose": "^5.9.6",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -4,28 +4,41 @@ startCommand:
   type: stdio
   configSchema:
     # JSON Schema defining the configuration options for the MCP.
+    # Pick ONE auth mode: JWT (recommended) or API Key (legacy, deprecated 2027).
     type: object
     required:
       - qweatherApiBase
-      - qweatherApiKey
     properties:
       qweatherApiBase:
         type: string
-        description: The base URL for QWeather API. E.g., https://api.qweather.com
+        description: The base URL for QWeather API. E.g., https://api.qweather.com or https://<host>.qweatherapi.com
       qweatherApiKey:
         type: string
-        description: Your QWeather API key.
+        description: (Legacy API Key auth) Your QWeather API key. Will be deprecated by QWeather in 2027.
+      qweatherProjectId:
+        type: string
+        description: (JWT auth) QWeather project ID, used as JWT `sub` claim.
+      qweatherKeyId:
+        type: string
+        description: (JWT auth) QWeather credential ID, used as JWT `kid` header.
+      qweatherPrivateKey:
+        type: string
+        description: (JWT auth) Ed25519 private key in PKCS8 PEM format. Newlines must be preserved.
+      qweatherPrivateKeyPath:
+        type: string
+        description: (JWT auth) Path to an Ed25519 PKCS8 PEM file. Takes precedence over qweatherPrivateKey if both are set.
   commandFunction:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
-    (config) => ({
-      command: 'node',
-      args: ['cli.js'],
-      env: {
-        QWEATHER_API_BASE: config.qweatherApiBase,
-        QWEATHER_API_KEY: config.qweatherApiKey
-      }
-    })
+    (config) => {
+      const env = { QWEATHER_API_BASE: config.qweatherApiBase };
+      if (config.qweatherApiKey) env.QWEATHER_API_KEY = config.qweatherApiKey;
+      if (config.qweatherProjectId) env.QWEATHER_PROJECT_ID = config.qweatherProjectId;
+      if (config.qweatherKeyId) env.QWEATHER_KEY_ID = config.qweatherKeyId;
+      if (config.qweatherPrivateKey) env.QWEATHER_PRIVATE_KEY = config.qweatherPrivateKey;
+      if (config.qweatherPrivateKeyPath) env.QWEATHER_PRIVATE_KEY_PATH = config.qweatherPrivateKeyPath;
+      return { command: 'node', args: ['cli.js'], env };
+    }
   exampleConfig:
     qweatherApiBase: https://api.qweather.com
     qweatherApiKey: dummy-api-key-123456

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,123 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { readFileSync } from "node:fs";
+import { SignJWT, importPKCS8, type KeyLike } from "jose";
 import { z } from "zod";
 
 const QWEATHER_API_BASE = process.env.QWEATHER_API_BASE
 if (!QWEATHER_API_BASE) {
     throw new Error("QWEATHER_API_BASE env is not set")
 }
-const QWEATHER_API_KEY = process.env.QWEATHER_API_KEY
-if (!QWEATHER_API_KEY) {
-    throw new Error("QWEATHER_API_KEY env is not set")
+
+// Authentication mode detection.
+// JWT mode requires: QWEATHER_PROJECT_ID + QWEATHER_KEY_ID + (QWEATHER_PRIVATE_KEY or QWEATHER_PRIVATE_KEY_PATH).
+// API Key mode requires: QWEATHER_API_KEY (legacy, deprecated by QWeather in 2027).
+type AuthMode =
+    | { kind: "jwt"; projectId: string; keyId: string; privateKeyPem: string }
+    | { kind: "apiKey"; apiKey: string };
+
+function detectAuthMode(): AuthMode {
+    const projectId = process.env.QWEATHER_PROJECT_ID;
+    const keyId = process.env.QWEATHER_KEY_ID;
+    const privateKeyInline = process.env.QWEATHER_PRIVATE_KEY;
+    const privateKeyPath = process.env.QWEATHER_PRIVATE_KEY_PATH;
+    const apiKey = process.env.QWEATHER_API_KEY;
+
+    const hasJwtCore = Boolean(projectId && keyId);
+    const hasJwtKey = Boolean(privateKeyInline || privateKeyPath);
+    const hasAnyJwtVar = Boolean(projectId || keyId || privateKeyInline || privateKeyPath);
+
+    if (hasJwtCore && hasJwtKey) {
+        // _PATH takes precedence over inline PEM (more conventional for key material).
+        let privateKeyPem: string;
+        if (privateKeyPath) {
+            try {
+                privateKeyPem = readFileSync(privateKeyPath, "utf8");
+            } catch (err) {
+                throw new Error(`Failed to read QWEATHER_PRIVATE_KEY_PATH (${privateKeyPath}): ${(err as Error).message}`);
+            }
+        } else {
+            // Shell/.env exports often pass `\n` as the literal two-char sequence;
+            // normalize so users don't have to embed real newlines manually.
+            privateKeyPem = (privateKeyInline as string).replace(/\\n/g, "\n");
+        }
+        return {
+            kind: "jwt",
+            projectId: projectId as string,
+            keyId: keyId as string,
+            privateKeyPem,
+        };
+    }
+
+    // Incomplete JWT setup must not silently fall back to API Key — the user almost
+    // certainly intended to use JWT and would otherwise never realize it didn't take effect.
+    if (hasAnyJwtVar && !(hasJwtCore && hasJwtKey)) {
+        if (apiKey) {
+            console.warn(
+                "[qweather-mcp] Incomplete JWT configuration detected; falling back to QWEATHER_API_KEY. " +
+                "To use JWT, set QWEATHER_PROJECT_ID, QWEATHER_KEY_ID, and QWEATHER_PRIVATE_KEY[_PATH]."
+            );
+            return { kind: "apiKey", apiKey };
+        }
+        throw new Error(
+            "Incomplete JWT configuration. Set QWEATHER_PROJECT_ID, QWEATHER_KEY_ID, and one of QWEATHER_PRIVATE_KEY / QWEATHER_PRIVATE_KEY_PATH; or remove the JWT vars and set QWEATHER_API_KEY instead."
+        );
+    }
+
+    if (apiKey) {
+        return { kind: "apiKey", apiKey };
+    }
+
+    throw new Error(
+        "No QWeather credentials configured. Set either JWT env vars (QWEATHER_PROJECT_ID + QWEATHER_KEY_ID + QWEATHER_PRIVATE_KEY[_PATH]) or QWEATHER_API_KEY."
+    );
+}
+
+const AUTH_MODE = detectAuthMode();
+
+// JWT token cache: re-sign only when the cached token is within ~30s of expiry.
+const JWT_TTL_SECONDS = 900; // 15 minutes, well under QWeather's 24h cap
+const JWT_REFRESH_LEEWAY_SECONDS = 30;
+const JWT_IAT_BACKDATE_SECONDS = 30; // guard against minor clock skew
+
+let cachedJwt: { token: string; expiresAt: number } | null = null;
+let cachedPrivateKey: KeyLike | null = null;
+
+async function getJwtToken(jwt: Extract<AuthMode, { kind: "jwt" }>): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (cachedJwt && cachedJwt.expiresAt - now > JWT_REFRESH_LEEWAY_SECONDS) {
+        return cachedJwt.token;
+    }
+
+    if (!cachedPrivateKey) {
+        try {
+            cachedPrivateKey = await importPKCS8(jwt.privateKeyPem, "EdDSA");
+        } catch (err) {
+            throw new Error(
+                `Failed to parse Ed25519 private key. Expected PKCS#8 PEM beginning with "-----BEGIN PRIVATE KEY-----". Underlying error: ${(err as Error).message}`
+            );
+        }
+    }
+
+    const iat = now - JWT_IAT_BACKDATE_SECONDS;
+    const exp = iat + JWT_TTL_SECONDS;
+    const token = await new SignJWT({})
+        .setProtectedHeader({ alg: "EdDSA", kid: jwt.keyId })
+        .setIssuedAt(iat)
+        .setExpirationTime(exp)
+        .setSubject(jwt.projectId)
+        .sign(cachedPrivateKey);
+
+    cachedJwt = { token, expiresAt: exp };
+    return token;
+}
+
+async function buildAuthHeaders(): Promise<Record<string, string>> {
+    if (AUTH_MODE.kind === "apiKey") {
+        return { "X-QW-Api-Key": AUTH_MODE.apiKey };
+    }
+    const token = await getJwtToken(AUTH_MODE);
+    return { Authorization: `Bearer ${token}` };
 }
 
 // Create server instance
@@ -39,11 +148,8 @@ async function makeQWeatherRequest<T>(endpoint: string, params: Record<string, s
     });
 
     try {
-        const response = await fetch(url.toString(), {
-            headers: {
-                'X-QW-Api-Key': QWEATHER_API_KEY as string
-            }
-        });
+        const headers = await buildAuthHeaders();
+        const response = await fetch(url.toString(), { headers });
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}, URL: ${url.toString()}`);
         }
@@ -1270,7 +1376,7 @@ function translateAdvice(advice: string): string {
 async function main() {
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error("Weather MCP Server running on stdio");
+    console.error(`Weather MCP Server running on stdio (auth: ${AUTH_MODE.kind === "jwt" ? "JWT/EdDSA" : "API Key"})`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary

Adds JWT (EdDSA/Ed25519) authentication ahead of QWeather's planned API Key deprecation in 2027, while keeping the existing API Key flow fully working as a non-breaking fallback.

- **Auto mode detection** from env vars
  - Full JWT vars (`QWEATHER_PROJECT_ID` + `QWEATHER_KEY_ID` + `QWEATHER_PRIVATE_KEY[_PATH]`) → JWT (wins even if `QWEATHER_API_KEY` is also set)
  - Partial JWT vars + `QWEATHER_API_KEY` → API Key, with a stderr warning so silent misconfiguration is impossible
  - Partial JWT vars only → fail fast at startup
  - `QWEATHER_API_KEY` only → API Key (unchanged behavior)
- **JWT signing** via `jose`: `alg=EdDSA`, `kid` header, `sub=projectId`, `iat` back-dated 30s for clock skew, `exp = iat + 900s` (well under QWeather's 24h cap). Token and imported PKCS#8 key are cached and reused until ~30s before expiry.
- **Private key input**: `QWEATHER_PRIVATE_KEY` (inline PEM, literal `\n` auto-normalized to real newlines so shell/`.env` exports work) or `QWEATHER_PRIVATE_KEY_PATH` (file path, takes precedence). Bad PEM produces a friendly error pointing at PKCS#8 format.
- **Transport**: `Authorization: Bearer <jwt>`; API Key path unchanged (`X-QW-Api-Key`).
- **Docs**: README (en/zh) covers both modes, the precedence table, the `\n` shell behavior, and the startup auth-mode stderr log line.
- **Smithery**: `smithery.yaml` exposes the new JWT fields; `commandFunction` only forwards env vars the user actually supplied.

Closes #6

## Test plan

End-to-end already verified against a real QWeather account with the dedicated JWT API host:

- [x] `npm run build` passes
- [x] Six auth-detection scenarios behave as expected (full JWT, full JWT + API Key, partial JWT + API Key, partial JWT only, API Key only, nothing)
- [x] Startup log line correctly reports `auth: JWT/EdDSA` vs `auth: API Key`
- [x] `tools/call get-weather-now` returns live data with JWT auth (verified against `*.qweatherapi.com` host)
- [ ] Reviewer to spot-check the PEM `\n` normalization behavior with their own `.env`
- [ ] Reviewer to confirm API Key flow still works for existing users (no env changes on their side)